### PR TITLE
github-graphql-query.sh: fix reviewed-by tags on Ubuntu systems

### DIFF
--- a/github-graphql-query.sh
+++ b/github-graphql-query.sh
@@ -194,7 +194,7 @@ do
 
 	#cherry-pick and amend commit to add reviewed-by tags
 	git cherry-pick $SHA >&/dev/null
-	git rebase HEAD~1 -x 'git commit --amend -m "$(git log --format=%B -n1)$(echo -e '"$reviewed"')"' >&/dev/null
+	git rebase HEAD~1 -x 'git commit --amend -m "$(git log --format=%B -n1)$(/bin/echo -e '"$reviewed"')"' >&/dev/null
 done
 
 rm users.json


### PR DESCRIPTION
An additional "-e" was added to the signed-off-by lines on
systems with non-bash default shell (e.g. default dash in Ubuntu).
The echo command in dash does not know about "-e", so it ends
up in output (but escape sequences are handled by default). In
bash, the "-e" option has to be added to handle the newfeed
properly.

Fix the issue by using /bin/echo directly.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>